### PR TITLE
andor3.cpp: fix for when SDK does not call back change in buffer size wh...

### DIFF
--- a/andor3App/src/andor3.cpp
+++ b/andor3App/src/andor3.cpp
@@ -828,6 +828,9 @@ int andor3::setAOI()
     status |= AT_SetInt(handle_, L"AOILeft",   minX);
     status |= AT_SetInt(handle_, L"AOIHeight", sizeY/binY);
     status |= AT_SetInt(handle_, L"AOITop",    minY);
+
+    allocateBuffers();
+
     return status;
 }
 
@@ -915,7 +918,9 @@ int andor3::allocateBuffers(void)
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s:allocateBuffers: Failed to allocate and queue buffers\n",
             driverName);
-    }   
+    } else {
+      setIntegerParam(NDArraySize, size);
+    }  
     return status;
 }
 


### PR DESCRIPTION
...en setting ROI parameters.

I found that without this patch the buffer size was not updated when I changed the ROI settings on the camera.
