### PR TITLE
andor3.cpp: remove the hard coded time stamp offset (631152000) so we…

### DIFF
--- a/andor3App/src/andor3.cpp
+++ b/andor3App/src/andor3.cpp
@@ -285,7 +285,7 @@ void andor3::imageTask()
             }
             if(pImage) {
                 pImage->uniqueId = count;
-                pImage->timeStamp = 631152000 + imageStamp.secPastEpoch +
+                pImage->timeStamp = imageStamp.secPastEpoch +
                     (imageStamp.nsec / 1.0e9);
                 updateTimeStamp(&pImage->epicsTS);
 


### PR DESCRIPTION
… use EPICS time rather than POSIX time. This fixes issue #6.